### PR TITLE
added service AR association to tag model

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,4 +1,5 @@
 class Tag < ActiveRecord::Base
   has_many :service_tags
+  has_many :services, through: :service_tags
   validates :name, presence: true
 end


### PR DESCRIPTION
@wiliajc87 @dschmura @gphummer I forgot to add an essential active-record association to the Tag model in my last PR, so this one fixes it. You can now to tag.services to see all services related to a tag. Enjoy.