### PR TITLE
Multiple filters

### DIFF
--- a/app/services/record_query_service.rb
+++ b/app/services/record_query_service.rb
@@ -20,6 +20,15 @@ class RecordQueryService
     options[:offset] ? scope.skip(options[:offset]) : scope
   end
 
+  def with_filters(scope)
+    if options[:filter]
+      # Ex. zip=63630$district=17$city=Chicago => [[:zip, 63630], [:district, 17], [:city, "Chicago"]]
+      scope.where(Hash[format_pairs])
+    else
+      scope
+    end
+  end
+
   def with_limit(scope)
     options[:limit] ? scope.limit(options[:limit]) : scope
   end

--- a/app/services/record_query_service.rb
+++ b/app/services/record_query_service.rb
@@ -40,4 +40,17 @@ class RecordQueryService
       scope
     end
   end
+
+  def format_pairs
+    filters = options[:filter].split("$").map do |filter|
+      filter_pair = filter.split("=")
+      key, value = filter_pair[0], filter_pair[1]
+      #make the first element a symbol
+      filter_pair[0] = key.to_sym
+      #make the second element an integer if necessary
+      filter_pair[1] = value.to_i if value == value.to_i.to_s
+      filter_pair
+    end
+  end
+
 end

--- a/app/services/record_query_service.rb
+++ b/app/services/record_query_service.rb
@@ -8,6 +8,7 @@ class RecordQueryService
 
   def fetch_records
     scope = service.records
+    scope = with_filters(scope)
     scope = with_offset(scope)
     scope = with_limit(scope)
     scope = with_sort(scope)


### PR DESCRIPTION
this method allows two methods to query
(multiple filter fields in query string--note that %3D is the URL encoded format of '=' )
&filter=city%3DChicago&filter=zip%3D60630
OR
(separate each by a dollar sign(%24))
&filter=city%3DChicago%24zip%3D60630